### PR TITLE
Modified low battery alarm to require the battery to remain below the…

### DIFF
--- a/LLPP.ino
+++ b/LLPP.ino
@@ -546,7 +546,7 @@ void low_batt_alarm(void)
         break;
 
       case low_batt:
-	    if ((millis() - low_batt_ms) > LOW_BATT_DELAY)
+        if ((millis() - low_batt_ms) > LOW_BATT_DELAY)
           alarm_state = on;
         break;
 	 }

--- a/LLPP.ino
+++ b/LLPP.ino
@@ -539,7 +539,7 @@ void low_batt_alarm(void)
   if ((bat_volts < NO_BAT) || (bat_volts > LOW_BATT_ALARM)) // Battery disconnected or over trigger voltage immediately disables alarm
     alarm_state = off;
   else if ((bat_volts > NO_BAT) && (bat_volts < LOW_BATT_ALARM)) { // Battery is within the alarm voltage range
-	switch (alarm_state) {
+    switch (alarm_state) {
       case off:
         low_batt_ms = millis();
         alarm_state = low_batt;

--- a/LLPP.ino
+++ b/LLPP.ino
@@ -541,13 +541,13 @@ void low_batt_alarm(void)
   else if ((bat_volts > NO_BAT) && (bat_volts < LOW_BATT_ALARM)) { // Battery is within the alarm voltage range
 	switch (alarm_state) {
       case off:
-	    low_batt_ms = millis();
-		alarm_state = low_batt;
+        low_batt_ms = millis();
+        alarm_state = low_batt;
         break;
 
       case low_batt:
 	    if ((millis() - low_batt_ms) > LOW_BATT_DELAY)
-		   alarm_state = on;
+          alarm_state = on;
         break;
 	 }
   }


### PR DESCRIPTION
… trigger voltage for a specified number of ms before the alarm is audible.  Default value equates to 30 seconds below the warning voltage.  This should prevent the alarm from being triggered by a transient drop in voltage due to sudden large current draw from the battery.